### PR TITLE
fix: add `"types"` key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "version": "1.0.0",
   "description": "Generated TypeScript definitions based on GitHub's OpenAPI spec",
   "main": "generated/types.ts",
+  "types": "generated/types.ts",
   "repository": "https://github.com/octokit/openapi-types.ts",
   "keywords": [],
   "author": "Gregor Martynus (https://twitter.com/gr2m)",


### PR DESCRIPTION
addresses https://github.com/octokit/rest.js/discussions/1708\#discussioncomment-227786 /cc @MKruschke