### PR TITLE
fix: stop exporting a TypeScript file as `"main"` field in `package.json`

### DIFF
--- a/generated/types.js
+++ b/generated/types.js
@@ -1,0 +1,1 @@
+// https://github.com/octokit/openapi-types.ts/issues/16#issuecomment-772784156

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "version": "1.0.0",
   "description": "Generated TypeScript definitions based on GitHub's OpenAPI spec",
-  "main": "generated/types.ts",
+  "main": "generated/types.js",
   "types": "generated/types.ts",
   "repository": "https://github.com/octokit/openapi-types.ts",
   "keywords": [],


### PR DESCRIPTION
closes #16 
![Screen Shot 2021-02-03 at 12 07 53 PM](https://user-images.githubusercontent.com/1192452/106802927-74d07980-6618-11eb-9055-0fd4936920c6.png)
