### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.2.0
+        with:
+          cache: npm
       - run: npm ci
       - run: npx semantic-release
         env:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.2.0
+        with:
+          cache: npm
       - run: npm ci
 
       # set gOCTOKIT_OPENAPI_VERSION environment variable for all next steps


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
