### PR TITLE
ci: stop testing against NodeJS v10, v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,8 @@
     "extends": [
       "github>octokit/.github"
     ]
+  },
+  "engines": {
+    "node": ">= 14"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Drop support for NodeJS v10, v12