### PR TITLE
build: when automatically pulling in changes from `@octokit/openapi`, automatically fix linting errors on the output

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -44,7 +44,7 @@ jobs:
           npm run update-package
         if: github.event_name != 'push'
       - name: Fix code formatting and style with Prettier (if required)
-        run: npx prettier -w .
+        run: npm run lint:fix
       - name: Create Pull Request
         if: github.event_name != 'push'
         uses: gr2m/create-or-update-pull-request-action@v1.x

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -43,6 +43,8 @@ jobs:
           npm run generate-types
           npm run update-package
         if: github.event_name != 'push'
+      - name: Fix code formatting and style with Prettier (if required)
+        run: npx prettier -w .
       - name: Create Pull Request
         if: github.event_name != 'push'
         uses: gr2m/create-or-update-pull-request-action@v1.x


### PR DESCRIPTION
This updates the "update" task which pulls in changes to `@octokit/openapi` to run Prettier and automatically fix code style and formatting issues.

If we assume that the code currently in `main` is valid from a linting perspective - which it should be, given our required checks, and this will only affect code that was actually generated by the update flow.