### PR TITLE
build: throw a less misleading error when the "update" task can't download generated files from Unpkg

### DIFF
--- a/scripts/download.js
+++ b/scripts/download.js
@@ -70,7 +70,11 @@ function download(version, fileName) {
   return new Promise((resolve, reject) => {
     get(url, (response) => {
       if (response.statusCode !== 200) {
-        throw new Error(`Not Found: ${url}`);
+        const errorDescription = [response.statusCode, response.statusMessage]
+          .filter(Boolean)
+          .join(" ");
+
+        throw new Error(`${errorDescription}: ${url}`);
       }
 
       response.pipe(file);


### PR DESCRIPTION
When we are unable to download one of the generated files from the `octokit/openapi` repo via `unpkg.com`, regardless of the true error, we throw an error saying "Not Found".

This is a bit misleading - especially right now when our "update" task is [failing][1] due to some downtime on `unpkg.com`'s side.

This corrects the code so it gives you an error message which truly describes what's going on.

[1]: https://github.com/octokit/openapi-types.ts/runs/7469277017?check_suite_focus=true