### PR TITLE
fix(build): allow download script to handle releases with more than 30 assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@octokit/core": "^4.0.0",
+        "@octokit/plugin-paginate-rest": "^3.1.0",
         "github-enterprise-server-versions": "^1.0.0",
         "openapi-typescript": "^5.0.0",
         "prettier": "2.7.1"
@@ -78,6 +79,21 @@
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
       "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ==",
       "dev": true
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-3.1.0.tgz",
+      "integrity": "sha512-+cfc40pMzWcLkoDcLb1KXqjX0jTGYXjKuQdFQDc6UAknISJHnZTiBqld6HDwRJvD4DsouDKrWXNbNV0lE/3AXA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^6.41.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=4"
+      }
     },
     "node_modules/@octokit/request": {
       "version": "6.2.0",
@@ -370,6 +386,15 @@
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
       "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ==",
       "dev": true
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-3.1.0.tgz",
+      "integrity": "sha512-+cfc40pMzWcLkoDcLb1KXqjX0jTGYXjKuQdFQDc6UAknISJHnZTiBqld6HDwRJvD4DsouDKrWXNbNV0lE/3AXA==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.41.0"
+      }
     },
     "@octokit/request": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@octokit/core": "^4.0.0",
+    "@octokit/plugin-paginate-rest": "^3.1.0",
     "github-enterprise-server-versions": "^1.0.0",
     "openapi-typescript": "^5.0.0",
     "prettier": "2.7.1"

--- a/scripts/download.js
+++ b/scripts/download.js
@@ -2,6 +2,7 @@ import { writeFileSync } from "node:fs";
 import { mkdir, rm } from "node:fs/promises";
 
 import { Octokit } from "@octokit/core";
+import { paginateRest } from "@octokit/plugin-paginate-rest";
 import gheVersions from "github-enterprise-server-versions";
 const { getCurrentVersions } = gheVersions;
 
@@ -14,7 +15,9 @@ run(process.env.OCTOKIT_OPENAPI_VERSION.replace(/^v/, "")).then(
   console.error
 );
 
-const octokit = new Octokit({
+const OctokitWithPlugins = Octokit.plugin(paginateRest);
+
+const octokit = new OctokitWithPlugins({
   auth: process.env.GITHUB_TOKEN,
 });
 
@@ -30,7 +33,7 @@ async function run(version) {
     tag: `v${version}`,
   });
 
-  const { data: releaseAssets } = await octokit.request(
+  const releaseAssets = await octokit.paginate(
     "GET /repos/{owner}/{repo}/releases/{release_id}/assets",
     {
       owner: "octokit",


### PR DESCRIPTION
To download the built schemas from `octokit/openapi`, we use GitHub's "List release assets" API.

This API is paginated, which means that it will only by default return up to 30 assets. This can mean that we miss data when the script runs - e.g. see [this commit][1] where GitHub AE schemas were dropped.

This fixes the issue by using Octokit's pagination plugin to automatically cycle through pages and find all release assets. A more lightweight fix would have been to set the `per_page` attribute, but this is more correct and more future-proof.

[1]: https://github.com/octokit/openapi-types.ts/commit/2704936a30ae6916e415f89fc008d681f3f2268d