### PR TITLE
feat: force a major version to be shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Generated TypeScript definitions based on GitHub's OpenAPI spec
 
-This repository continously converts [GitHub's OpenAPI specification](https://github.com/github/rest-api-description/) into TypeScript definitions and publishes them to npm as `@octokit/openapi-types`
+This repository continously converts [GitHub's OpenAPI specification](https://github.com/github/rest-api-description/) into TypeScript definitions and publishes them to npm as `@octokit/openapi-types`.
 
 ## License
 


### PR DESCRIPTION
_NB: These changes were shipped in #251, but the merge commit did not contain the correct message to trigger a major version release. This tiny PR should trigger a major version._

* feat: publish new `@octokit/openapi-types-ghec` package with types for APIs supported by GitHub Enterprise Cloud, including GitHub Enterprise Cloud-exclusive APIs not available to other customers on `api.github.com`
* feat: remove types for GitHub Enterprise Cloud (GHEC) specific APIs from the `@octokit/openapi-types` package

BREAKING CHANGE: Types for API operations only available to GitHub Enterprise Cloud (GHEC) customers will no longer appear in the `@octokit/openapi-types` package. These will only appear in the GHEC-specific `@octokit/openapi-types-ghec` package. The `@octokit/openapi-types` package now only includes APIs available to customers on GitHub.com using the Free, Pro and Teams plans.

* feat: add support for new "Get a Dependabot alert" API (`GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number}`)
* feat: add support for new "Update a Dependabot alert" API (`PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number}`)
* feat: add support for new "List Dependabot alerts for a repository" API (`GET /repos/{owner}/{repo}/dependabot/alerts`)
* fix: tweak documentation for repo starring related APIs (`GET /repos/{owner}/{repo}/stargazers`, `GET /users/{username}/starred` and `GET /user/starred`) to clarify what `Accept` header to send to get information about when stars were created
* fix: tweak documentation for "Get community profile metrics" API (`GET /repos/{owner}/{repo}/community/profile`) to clarify that it only works with public repos which are not forks
* fix: document the `size` attribute returned on repos across the API
* fix: document that APIs can return `422` errors when an endpoint has been spammed with many requests
* fix: document `301` status returned by labels-related APIs if the repo has been renamed or moved
* fix: document `404 Not Found` status returned by labels-related APIs
* feat: add support for new "List organization secret" (`GET /organizations/{org}/codespaces/secrets`) Codespaces API
* feat: add support for new "Get an organization public key" (`GET /organizations/{org}/codespaces/secrets/public-key`) Codespaces API
* feat: add support for new "Get an organization secret" (`GET /organizations/{org}/codespaces/secrets/{secret_name}` ) Codespaces API
* feat: adds support for new "Create or update an organization secret" (`PUT /organizations/{org}/codespaces/secrets/{secret_name}` ) Codespaces API
* feat: add support for new "Delete an organization secret"  (`DELETE /organizations/{org}/codespaces/secrets/{secret_name}`) Codespaces API
* feat: add support for new "List selected repositories for an organization secret" (`GET /organizations/{org}/codespaces/secrets/{secret_name}/repositories`) Codespaces API
* feat: add support for new "Set selected repositories for an organization secret" ( `PUT /organizations/{org}/codespaces/secrets/{secret_name}/repositories`) Codespaces API
* feat: add support for new "Add selected repository to an organization secret" (`PUT /organizations/{org}/codespaces/secrets/{secret_name}/repositories/{repository_id}`) Codespaces API
* feat: add support for new "Remove selected repository from an organization secret" (`DELETE /organizations/{org}/codespaces/secrets/{secret_name}/repositories/{repository_id}`) Codespaces API
* feat: add support for `resolution_comment` attribute returned on secret scanning alerts
* feat: add support for new `scope` attribute returned by the "Get a diff of the dependencies between commits" (`GET /repos/{owner}/{repo}/dependency-graph/compare/{basehead}`) API