### PR TITLE
build(deps): bump `github-enterprise-server-versions`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@octokit/core": "^4.0.0",
         "@octokit/plugin-paginate-rest": "^6.0.0",
-        "github-enterprise-server-versions": "^1.0.0",
+        "github-enterprise-server-versions": "^1.1.1",
         "openapi-typescript": "^6.2.1",
         "prettier": "2.8.8"
       }
@@ -259,9 +259,9 @@
       }
     },
     "node_modules/github-enterprise-server-versions": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/github-enterprise-server-versions/-/github-enterprise-server-versions-1.1.0.tgz",
-      "integrity": "sha512-BIYEVOh4qjyDoGGoQFc5XJtASj+VZL4WsgcXc58v+i6YXhRMV+zJTtnbxG0rxqdTLcFTDX2xCXKgkPvdC4Seqg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/github-enterprise-server-versions/-/github-enterprise-server-versions-1.1.1.tgz",
+      "integrity": "sha512-X58C3XK2Q69khnfpZUvv7++rFXq4WQkYREX6K4ct8A2UmvZU/rpny5XIUjreGU4dQunEQhefYcLw0ZyOFewvqA==",
       "dev": true,
       "dependencies": {
         "node-fetch": "^2.6.1"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@octokit/core": "^4.0.0",
     "@octokit/plugin-paginate-rest": "^6.0.0",
-    "github-enterprise-server-versions": "^1.0.0",
+    "github-enterprise-server-versions": "^1.1.1",
     "openapi-typescript": "^6.2.1",
     "prettier": "2.8.8"
   },


### PR DESCRIPTION
This fixes OpenAPI updates, as the current endpoint returns a 404 and this update fixes that

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->

<!-- Issues are required for both bug fixes and features. -->

Resolves #ISSUE_NUMBER

---

## Behavior

### Before the change?

<!-- Please describe the current behavior that you are modifying. -->

- The `update` workflow would fail with a 404 while fetching the GHES release dates

### After the change?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The `update` workflow now doesn't fail while fetching the GHES releases

### Other information

<!-- Any other information that is important to this PR  -->

- ***

## Additional info

### Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?

<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

- N/A

### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please add the corresponding label for change this PR introduces:

- Dependencies/code cleanup: `Type: Maintenance`

---
