### PR TITLE
build: fix prettier usage

### DIFF
--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -40,7 +40,7 @@ async function run() {
     await mkdir(`packages/${packageName}`);
     await writeFile(
       `packages/${packageName}/package.json`,
-      prettier.format(
+      await prettier.format(
         JSON.stringify({
           name: `@octokit/${packageName}`,
           description: `Generated TypeScript definitions based on GitHub's OpenAPI spec for ${name}`,
@@ -56,7 +56,7 @@ async function run() {
     );
     await writeFile(
       `packages/${packageName}/README.md`,
-      prettier.format(
+      await prettier.format(
         `
 # @octokit/${packageName}
 
@@ -86,7 +86,7 @@ type Repository = components["schemas"]["full-repository"]
 
     await writeFile(
       `packages/${packageName}/types.d.ts`,
-      prettier.format(await openapiTS(`cache/${name}.json`), {
+      await prettier.format(await openapiTS(`cache/${name}.json`), {
         parser: "typescript",
       }),
     );

--- a/scripts/update-package.js
+++ b/scripts/update-package.js
@@ -31,6 +31,6 @@ async function updatePackage() {
 
   await writeFile(
     "package.json",
-    prettier.format(JSON.stringify(pkg), { parser: "json-stringify" }),
+    await prettier.format(JSON.stringify(pkg), { parser: "json-stringify" }),
   );
 }


### PR DESCRIPTION
Prettier is async since v3
This unblocks automated updates

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The build scripts would fail because `fs.writeFile()` was receiving a `Promise`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* `await` the call to prettier

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

