### PR TITLE
build: strip out `.json` file extension when comparing GHES versions

### DIFF
--- a/scripts/download.js
+++ b/scripts/download.js
@@ -49,7 +49,11 @@ async function run(version) {
     if (/diff/.test(asset.name)) continue;
 
     if (/^ghes-/.test(asset.name)) {
-      if (!currentGHESVersions.includes(asset.name.substr("ghes-".length).replace(/\.json$/, ""))) {
+      if (
+        !currentGHESVersions.includes(
+          asset.name.substr("ghes-".length).replace(/\.json$/, ""),
+        )
+      ) {
         continue;
       }
     }

--- a/scripts/download.js
+++ b/scripts/download.js
@@ -49,7 +49,7 @@ async function run(version) {
     if (/diff/.test(asset.name)) continue;
 
     if (/^ghes-/.test(asset.name)) {
-      if (!currentGHESVersions.includes(asset.name.substr("ghes-".length))) {
+      if (!currentGHESVersions.includes(asset.name.substr("ghes-".length).replace(/\.json$/, ""))) {
         continue;
       }
     }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The download script would fail to download GHES versions

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The download script can now download GHES versions with no issues

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

